### PR TITLE
Fix asset downloading authentication error

### DIFF
--- a/lib/github_export/command.rb
+++ b/lib/github_export/command.rb
@@ -108,7 +108,12 @@ module GithubExport
             if options[:force] || !File.exist?(dest)
               verbose "DL #{url}"
               FileUtils.mkdir_p(File.dirname(dest))
-              File.binwrite(dest, client.get(url))
+              # Assets might be downloaded from S3 so we use curl (or httpclient?) without auth info instead of `client` object
+              # File.binwrite(dest, client.get(url))
+              cmd = "curl -o #{dest} #{url}"
+              unless system(cmd)
+                puts "Download Error #{cmd}"
+              end
             else
               verbose "SKIP #{url}"
             end

--- a/lib/github_export/command.rb
+++ b/lib/github_export/command.rb
@@ -110,7 +110,7 @@ module GithubExport
               FileUtils.mkdir_p(File.dirname(dest))
               # Assets might be downloaded from S3 so we use curl (or httpclient?) without auth info instead of `client` object
               # File.binwrite(dest, client.get(url))
-              cmd = "curl -o #{dest} #{url}"
+              cmd = "curl -f -o #{dest} #{url}"
               unless system(cmd)
                 puts "Download Error #{cmd}"
               end

--- a/lib/github_export/version.rb
+++ b/lib/github_export/version.rb
@@ -1,3 +1,3 @@
 module GithubExport
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Fix the following error.
It seems that `client` of `octokit` sends request with authentication header for github, but S3 which might store asset files doesn't accept the authentication header for github.
This PR changes to send the requests to S3 with `curl` command instead of `client` of `octokit` .

## Error

```
$ exe/github_export assets_download -n 1 -d tmp/msa_apps-20180409 -t xxxxxxxxxxxxxx -V
(snip)
Traceback (most recent call last):
	23: from exe/github_export:4:in `<main>'
	22: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
	21: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
	20: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
	19: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
	18: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:103:in `assets_download'
	17: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:103:in `each'
	16: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:104:in `block in assets_download'
	15: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:104:in `fork'
	14: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:105:in `block (2 levels) in assets_download'
	13: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:105:in `each'
	12: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/github_export-0.1.1/lib/github_export/command.rb:111:in `block (3 levels) in assets_download'
	11: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/connection.rb:19:in `get'
	10: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/connection.rb:156:in `request'
	 9: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
	 8: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.9.1/lib/faraday/connection.rb:140:in `get'
	 7: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.9.1/lib/faraday/connection.rb:377:in `run_request'
	 6: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.9.1/lib/faraday/rack_builder.rb:139:in `build_response'
	 5: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
	 4: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
	 3: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.9.1/lib/faraday/response.rb:8:in `call'
	 2: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.9.1/lib/faraday/response.rb:57:in `on_complete'
	 1: from $HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/faraday-0.9.1/lib/faraday/response.rb:9:in `block in call'
$HOME/.anyenv/envs/rbenv/versions/2.5.0/lib/ruby/gems/2.5.0/gems/octokit-4.8.0/lib/octokit/response/raise_error.rb:16:in `on_complete': GET https://cloud.githubusercontent.com/assets/xxxxxxxxxxxxxxxxxxxx/xxxxxxxxxxxxxxxxxxx.png: 400 - <?xml version="1.0" encoding="UTF-8"?> (Octokit::BadRequest)
<Error><Code>InvalidArgument</Code><Message>Unsupported Authorization Type</Message><ArgumentName>Authorization</ArgumentName><ArgumentValue>token xxxxxxxxxxxxxx</ArgumentValue><RequestId>xxxxxxxxxxxxxxxxxxxxxx</RequestId><HostId>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</HostId></Error>
```
